### PR TITLE
Add retries and improve time zone handling

### DIFF
--- a/R/bomWater.R
+++ b/R/bomWater.R
@@ -11,7 +11,7 @@
 #' if there is no data available for that query.
 #' @author Alexander Buzacott
 make_bom_request <- function(params) {
-  bom_url <- "http://www.bom.gov.au/waterdata/services"
+  bom_url <- httr::parse_url("http://www.bom.gov.au/waterdata/services")
 
   base_params <- list(
     "service" = "kisters",
@@ -19,10 +19,12 @@ make_bom_request <- function(params) {
     "format" = "json"
   )
 
+  bom_url$query <- c(base_params, params)
+
   r <- tryCatch(
     {
-      r <- httr::GET(bom_url, query = c(base_params, params))
-      httr::stop_for_status(r, task = "request water data form BoM")
+      r <- httr::RETRY("GET", bom_url, times = 5, quiet = TRUE)
+      httr::stop_for_status(r, task = "request water data from BoM")
       httr::warn_for_status(r, task = "request water data from BoM")
     },
     error = function(e) {
@@ -56,9 +58,9 @@ make_bom_request <- function(params) {
     column_names <- unlist(stringr::str_split(json$columns, ","))
     if (length(json$data[[1]]) == 0) {
       tbl <- tibble::tibble(
-        Timestamp = character(),
-        Value = character(),
-        `Quality Code` = character()
+        Timestamp = lubridate::as_datetime(lubridate::ymd()),
+        Value = numeric(),
+        `Quality Code` = integer()
       )
     } else {
       colnames(json$data[[1]]) <- column_names

--- a/R/bomWater.R
+++ b/R/bomWater.R
@@ -11,7 +11,7 @@
 #' if there is no data available for that query.
 #' @author Alexander Buzacott
 make_bom_request <- function(params) {
-  bom_url <- httr::parse_url("http://www.bom.gov.au/waterdata/services")
+  bom_url <- "http://www.bom.gov.au/waterdata/services"
 
   base_params <- list(
     "service" = "kisters",
@@ -19,11 +19,9 @@ make_bom_request <- function(params) {
     "format" = "json"
   )
 
-  bom_url$query <- c(base_params, params)
-
   r <- tryCatch(
     {
-      r <- httr::RETRY("GET", bom_url, times = 5, quiet = TRUE)
+      r <- httr::RETRY("GET", bom_url, query = c(base_params, params), times = 5, quiet = TRUE)
       httr::stop_for_status(r, task = "request water data from BoM")
       httr::warn_for_status(r, task = "request water data from BoM")
     },

--- a/R/getSeries.R
+++ b/R/getSeries.R
@@ -130,7 +130,7 @@ get_timeseries <- function(parameter_type,
           tz <- "Australia/Queensland" # AEST
         } else if (jurisdiction %in% c("SA", "NT")) {
           tz <- "Australia/Darwin" # ACST
-        } else if (jursidiction == "WA") {
+        } else if (jurisdiction == "WA") {
           tz <- "Australia/Perth" # AWST
         } else {
           message("Jurisdiction not found, returning datetimes in UTC")

--- a/R/getSeries.R
+++ b/R/getSeries.R
@@ -30,9 +30,9 @@
 #' (YYYY-MM-DD).
 #' @param end_date End date formatted as a string or date class (YYYY-MM-DD).
 #' @param tz Optional: the desired time zone for the output timeseries. Input
-#' must be an Olson Name (see `OlsonNames()`). By default the the timeseries
-#' is returned in an offset timezone (e.g. `Etc/GMT-10` for NSW) as the
-#' timeseries do not observe DST.
+#' must be an Olson Name (see `OlsonNames()`). By default the timeseries are
+#' returned in non-DST time zones (AEST, ACST or AWST) depending on the
+#' station location.
 #' @param return_fields Optional: columns to be returned from Water Data Online.
 #' By default Timestamp, Value and Quality Code are returned.
 #' @param ts_name The timeseries name (e.g. DMQaQc.Merged.DailyMean.24HR) that

--- a/man-roxygen/timeseriesDocs.R
+++ b/man-roxygen/timeseriesDocs.R
@@ -11,9 +11,9 @@
 #' (YYYY-MM-DD).
 #' @param end_date End date formatted as a string or date class (YYYY-MM-DD).
 #' @param tz Optional: the desired time zone for the output timeseries. Input
-#' must be an Olson Name (see `OlsonNames()`). By default the the timeseries
-#' is returned in an offset timezone (e.g. `Etc/GMT-10` for NSW) as the
-#' timeseries do not observe DST.
+#' must be an Olson Name (see `OlsonNames()`). By default the timeseries are
+#' returned in non-DST time zones (AEST, ACST or AWST) depending on the
+#' station location.
 #' @param return_fields Optional: columns to be returned from Water Data Online.
 #' By default Timestamp, Value and Quality Code are returned.
 #'

--- a/man/get_as_stored.Rd
+++ b/man/get_as_stored.Rd
@@ -25,9 +25,9 @@ Discharge). See \code{\link{parameters()}} for a full list.}
 \item{end_date}{End date formatted as a string or date class (YYYY-MM-DD).}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}

--- a/man/get_daily.Rd
+++ b/man/get_daily.Rd
@@ -35,9 +35,9 @@ midnight (`24HR`) or from 9am-9am (`09HR`). The default is `24HR`. `09HR`
 is only available for mean discharge and total rainfall and evaporation.}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}
@@ -90,7 +90,8 @@ get_daily(
   end_date = "2020-01-31",
   var = "mean",
   aggregation = "24HR"
-)}
+)
+}
 
 # Download daily mean aggregated between 9am to 9am
 \dontrun{
@@ -101,7 +102,8 @@ get_daily(
   end_date = "2020-01-31",
   var = "mean",
   aggregation = "09HR"
-)}
+)
+}
 
 # Download the daily max over the standard day
 \dontrun{
@@ -112,7 +114,8 @@ get_daily(
   end_date = "2020-01-31",
   var = "max",
   aggregation = "24HR"
-)}
+)
+}
 
 }
 \seealso{

--- a/man/get_hourly.Rd
+++ b/man/get_hourly.Rd
@@ -25,9 +25,9 @@ Discharge). See \code{\link{parameters()}} for a full list.}
 \item{end_date}{End date formatted as a string or date class (YYYY-MM-DD).}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}

--- a/man/get_monthly.Rd
+++ b/man/get_monthly.Rd
@@ -25,9 +25,9 @@ Discharge). See \code{\link{parameters()}} for a full list.}
 \item{end_date}{End date formatted as a string or date class (YYYY-MM-DD).}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}
@@ -78,7 +78,8 @@ get_monthly(
   station_number = "570947",
   start_date = "2016-01-01",
   end_date = "2016-06-01"
-)}
+)
+}
 }
 \seealso{
 \itemize{

--- a/man/get_timeseries.Rd
+++ b/man/get_timeseries.Rd
@@ -26,9 +26,9 @@ Discharge). See \code{\link{parameters()}} for a full list.}
 \item{end_date}{End date formatted as a string or date class (YYYY-MM-DD).}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}

--- a/man/get_yearly.Rd
+++ b/man/get_yearly.Rd
@@ -25,9 +25,9 @@ year (YYYY)}
 \item{end_date}{End date (formatted as YYYY-MM-DD) or just the year (YYYY)}
 
 \item{tz}{Optional: the desired time zone for the output timeseries. Input
-must be an Olson Name (see \code{OlsonNames()}). By default the the timeseries
-is returned in an offset timezone (e.g. \code{Etc/GMT-10} for NSW) as the
-timeseries do not observe DST.}
+must be an Olson Name (see \code{OlsonNames()}). By default the timeseries are
+returned in non-DST time zones (AEST, ACST or AWST) depending on the
+station location.}
 
 \item{return_fields}{Optional: columns to be returned from Water Data Online.
 By default Timestamp, Value and Quality Code are returned.}
@@ -78,7 +78,8 @@ get_yearly(
   station_number = "570946",
   start_date = 2016,
   end_date = 2020
-)}
+)
+}
 
 }
 \seealso{

--- a/tests/testthat/test-bomWater.R
+++ b/tests/testthat/test-bomWater.R
@@ -44,7 +44,7 @@ test_that("I can get a station list", {
   expect_equal(r$station_latitude, -35.64947222)
   expect_equal(r$station_longitude, 148.83144444)
 
-  if (not_cran != FALSE) {
+  if (not_cran != FALSE & internet == TRUE) {
     r <- get_station_list("Rainfall", c("570946", "410730"))
   } else {
     with_mock_api({

--- a/tests/testthat/test-bomWater.R
+++ b/tests/testthat/test-bomWater.R
@@ -1,4 +1,4 @@
-not_cran <- Sys.getenv('NOT_CRAN')
+not_cran <- Sys.getenv("NOT_CRAN")
 internet <- curl::has_internet()
 
 test_that("I can make requests to BoM", {
@@ -30,10 +30,10 @@ test_that("I can make requests to BoM", {
 
 test_that("I can get a station list", {
   if (not_cran != FALSE & internet == TRUE) {
-    r <- get_station_list("Rainfall", "570946")
+    r <- get_station_list("Rainfall", station_number = "570946")
   } else {
     with_mock_api({
-      r <- get_station_list("Rainfall", "570946")
+      r <- get_station_list("Rainfall", station_number = "570946")
     })
   }
   expect_equal(class(r)[1], "tbl_df")
@@ -45,10 +45,10 @@ test_that("I can get a station list", {
   expect_equal(r$station_longitude, 148.83144444)
 
   if (not_cran != FALSE & internet == TRUE) {
-    r <- get_station_list("Rainfall", c("570946", "410730"))
+    r <- get_station_list("Rainfall", station_number = c("570946", "410730"))
   } else {
     with_mock_api({
-      r <- get_station_list("Rainfall", c("570946", "410730"))
+      r <- get_station_list("Rainfall", station_number = c("570946", "410730"))
     })
   }
   expect_equal(class(r)[1], "tbl_df")
@@ -86,26 +86,26 @@ test_that("I can get timeseries values", {
   # Berthong annual rainfall
   if (not_cran != FALSE & internet == TRUE) {
     r <- get_timeseries_values(148131010,
-                               "2016-01-01",
-                               "2016-12-31",
-                               return_fields = c(
-                                 "Timestamp",
-                                 "Value",
-                                 "Quality Code",
-                                 "Interpolation Type"
-                               )
+      "2016-01-01",
+      "2016-12-31",
+      return_fields = c(
+        "Timestamp",
+        "Value",
+        "Quality Code",
+        "Interpolation Type"
+      )
     )
   } else {
     with_mock_api({
       r <- get_timeseries_values(148131010,
-                                 "2016-01-01",
-                                 "2016-12-31",
-                                 return_fields = c(
-                                   "Timestamp",
-                                   "Value",
-                                   "Quality Code",
-                                   "Interpolation Type"
-                                 )
+        "2016-01-01",
+        "2016-12-31",
+        return_fields = c(
+          "Timestamp",
+          "Value",
+          "Quality Code",
+          "Interpolation Type"
+        )
       )
     })
   }
@@ -117,24 +117,22 @@ test_that("I can get timeseries values", {
 })
 
 
-test_that("I get an error", {
+test_that("No results for parameter type and ID mistmatch", {
   if (not_cran != FALSE & internet == TRUE) {
-    expect_error(
-      get_timeseries_id(
+    r <- get_timeseries_id(
+      "Water Course Discharge",
+      "570946",
+      "DMQaQc.Merged.DailyMean.24HR"
+    )
+    expect_equal(nrow(r), 0)
+  } else {
+    with_mock_api({
+      r <- get_timeseries_id(
         "Water Course Discharge",
         "570946",
         "DMQaQc.Merged.DailyMean.24HR"
       )
-    )
-  } else {
-    with_mock_api({
-      expect_error(
-        get_timeseries_id(
-          "Water Course Discharge",
-          "570946",
-          "DMQaQc.Merged.DailyMean.24HR"
-        )
-      )
+      expect_equal(nrow(r), 0)
     })
   }
 })
@@ -171,4 +169,3 @@ test_that("get timeseries puts it all together", {
   expect_true(is.numeric(r$Value))
   expect_true(is.integer(r$`Quality Code`))
 })
-


### PR DESCRIPTION
Main changes:
- `httr:GET` changed to `httr:RETRY` as some requests are inconsistently failing
- Improved timezone handling. Now `bomWater` by default grabs the station jurisdiction and will update the timezone from there based on the text in the BOM FAQ:

> Which time zones are the data displayed in?
Time of day is presented in local standard time. Coordinated Universal Timezones (UTC) are:
Eastern States (QLD, NSW, ACT, VIC, TAS) - UTC +10:00
Central States (NT, SA) - UTC +09:30
Western Australia - UTC +08:00.

- Timezone can still be manually specified
- Closes #5 